### PR TITLE
BUG: the cache directory was used as a positional parameter in one line,

### DIFF
--- a/antspynet/utilities/desikan_killiany_tourville_labeling.py
+++ b/antspynet/utilities/desikan_killiany_tourville_labeling.py
@@ -216,7 +216,8 @@ def desikan_killiany_tourville_labeling(t1,
         weight_decay = 1e-5, add_attention_gating=True)
 
     weights_file_name = None
-    weights_file_name = get_pretrained_network("dktOuterWithSpatialPriors", antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("dktOuterWithSpatialPriors",
+                                               antsxnet_cache_directory=antsxnet_cache_directory)
     unet_model.load_weights(weights_file_name)
 
     ################################


### PR DESCRIPTION
causing it to be interpreted as a file name.

This led to a file under "~/.keras/ANTsXNet" called "ANTsXNet" instead of "dktOuterWithSpatialPriors.h5", which was causing problems when the cache directory path was specified as an absolute path.