### PR TITLE
PERF: set tf random seed

### DIFF
--- a/antspynet/utilities/hippmapp3r_segmentation.py
+++ b/antspynet/utilities/hippmapp3r_segmentation.py
@@ -183,6 +183,7 @@ def hippmapp3r_segmentation(t1,
     number_of_mci_iterations = 30
     prediction_refine_stage = np.zeros(shape_refine_stage)
     for i in range(number_of_mci_iterations):
+        tf.random.set_seed(i)
         if verbose == True:
             print("        Monte Carlo iteration", i + 1, "out of", number_of_mci_iterations)
         prediction_refine_stage = \
@@ -212,16 +213,3 @@ def hippmapp3r_segmentation(t1,
       whichtoinvert=[True], interpolator="genericLabel", verbose=verbose)
 
     return(segmentation_image)
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
just an attempt to make this process reproducible.

like many processes in ants-derived packages, there are issues with random seed (not set) and/or calls to ants.registration when multi-threading is used with mutual information metrics.  this pull request addresses only one of these issues.

one way to get around irreproducible registration when multi-threading is to use the GC metric (for low-dim reg) and the CC metric with radius 2 for deformable rather than Mattes MI.

