### PR TITLE
ENH: Check for data / networks in the cache before calling get_file

### DIFF
--- a/antspynet/utilities/get_antsxnet_data.py
+++ b/antspynet/utilities/get_antsxnet_data.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 import ants
-import os
+import os.path
 
 def get_antsxnet_data(file_id=None,
                       target_file_name=None,
@@ -107,7 +107,15 @@ def get_antsxnet_data(file_id=None,
     if antsxnet_cache_directory == None:
         antsxnet_cache_directory = "ANTsXNet"
 
-    target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
-        cache_subdir=antsxnet_cache_directory)
+    # keras get_file does not work on read-only file systems. It will attempt to download the file even
+    # if it exists. This is a problem for shared cache directories and read-only containers.
+    #
+    # Check if the file exists here, and if so, return it. Else let keras handle the download
+    target_file_name_path = os.path.join(os.path.expanduser('~'), '.keras', antsxnet_cache_directory,
+                                        target_file_name)
+
+    if not os.path.exists(target_file_name_path):
+        target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
+                                                        cache_subdir = antsxnet_cache_directory)
 
     return(target_file_name_path)

--- a/antspynet/utilities/get_pretrained_network.py
+++ b/antspynet/utilities/get_pretrained_network.py
@@ -1,3 +1,4 @@
+import os.path
 import tensorflow as tf
 
 def get_pretrained_network(file_id=None,
@@ -252,7 +253,15 @@ def get_pretrained_network(file_id=None,
     if antsxnet_cache_directory == None:
         antsxnet_cache_directory = "ANTsXNet"
 
-    target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
-        cache_subdir = antsxnet_cache_directory)
+    # keras get_file does not work on read-only file systems. It will attempt to download the file even
+    # if it exists. This is a problem for shared cache directories and read-only containers.
+    #
+    # Check if the file exists here, and if so, return it. Else let keras handle the download
+    target_file_name_path = os.path.join(os.path.expanduser('~'), '.keras', antsxnet_cache_directory,
+                                        target_file_name)
+
+    if not os.path.exists(target_file_name_path):
+        target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
+                                                        cache_subdir = antsxnet_cache_directory)
 
     return(target_file_name_path)


### PR DESCRIPTION
The keras method tf.keras.utils.get_file requires a writable cache directory, which precludes using
a read-only shared mount or a directory inside a singularity image to host the cache.

I looked at the source for tf.keras.utils.get_file and I think I have replicated its logic for finding the full target path. If the target does not exist, we proceed to call tf.keras.utils.get_file as before. 

This will allow me to build a singularity container with pre-downloaded data / networks, so that users can run it on our HPC that doesn't have Internet access, without a writable external mount that could get changed by accident and affect all users.