### PR TITLE
Add `__version__` to package

### DIFF
--- a/antspynet/__init__.py
+++ b/antspynet/__init__.py
@@ -1,8 +1,5 @@
 
-try:
-    from .version import __version__
-except:
-    pass
+__version__='0.2.2'
 
 from .architectures import *
 from .utilities import *

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,24 @@
 from setuptools import setup
+import os
 
 long_description = open("README.md").read()
 
+def read(rel_path: str) -> str:
+      here = os.path.abspath(os.path.dirname(__file__))
+      with open(os.path.join(here, rel_path)) as fp:
+            return fp.read()
+
+
+def get_version(rel_path: str) -> str:
+      for line in read(rel_path).splitlines():
+            if line.startswith("__version__"):
+                  delim = '"' if '"' in line else "'"
+                  return line.split(delim)[1]
+      raise RuntimeError("Unable to find version string.")
+
+
 setup(name='antspynet',
-      version='0.2.2',
+      version=get_version("antspynet/__init__.py"),
       description='A collection of deep learning architectures ported to the python language and tools for basic medical image processing.',
       long_description=long_description,
       long_description_content_type="text/markdown; charset=UTF-8; variant=GFM",


### PR DESCRIPTION
Using `pip` style (https://github.com/pypa/pip/blob/b88addeaf5fde848733d7ef631caa522eb1cfa53/setup.py#L7-L21) to add version string.

The version string is stored at `__init__.py` instead of `setup.py`.