### PR TITLE
ENH: Throw exception when getting data or networks without url

### DIFF
--- a/antspynet/utilities/get_antsxnet_data.py
+++ b/antspynet/utilities/get_antsxnet_data.py
@@ -119,6 +119,7 @@ def get_antsxnet_data(file_id=None,
 
     if antsxnet_cache_directory is None:
         antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
+
     target_file_name_path = os.path.join(antsxnet_cache_directory, target_file_name)
 
     # keras get_file does not work on read-only file systems. It will attempt to download the file even
@@ -126,6 +127,10 @@ def get_antsxnet_data(file_id=None,
     #
     # Check if the file exists here, and if so, return it. Else let keras handle the download
     if not os.path.exists(target_file_name_path):
+        if not url:
+            err_msg = 'The requested data "' + file_id + '" is not available'
+            raise NotImplementedError(err_msg)
+
         target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
                                                         cache_subdir=antsxnet_cache_directory)
 

--- a/antspynet/utilities/get_pretrained_network.py
+++ b/antspynet/utilities/get_pretrained_network.py
@@ -226,7 +226,7 @@ def get_pretrained_network(file_id=None,
                   "mriModalityClassification",
                   "protonLungMri",
                   "protonLobes",
-                  "pulmonaryArteryWeights", 
+                  "pulmonaryArteryWeights",
                   "sixTissueOctantBrainSegmentation",
                   "sixTissueOctantBrainSegmentationWithPriors1",
                   "sixTissueOctantBrainSegmentationWithPriors2",
@@ -262,6 +262,7 @@ def get_pretrained_network(file_id=None,
 
     if antsxnet_cache_directory is None:
         antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
+
     target_file_name_path = os.path.join(antsxnet_cache_directory, target_file_name)
 
     # keras get_file does not work on read-only file systems. It will attempt to download the file even
@@ -269,6 +270,10 @@ def get_pretrained_network(file_id=None,
     #
     # Check if the file exists here, and if so, return it. Else let keras handle the download
     if not os.path.exists(target_file_name_path):
+        if not url:
+            err_msg = 'The requested network "' + file_id + '" is not available'
+            raise NotImplementedError(err_msg)
+
         target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
                                                         cache_subdir=antsxnet_cache_directory)
 


### PR DESCRIPTION
@ntustison this will help me with containerized versions that get local copies of the data. Some entries in the list have empty strings as placeholders.

I put the check for a valid URL right before the download happens - so if you are testing locally you can put the files in place and call get_pretrained_network or get_antsxnet_data. But it will throw a `NotImplementedError` if you try to download them.