### PR TITLE
fix typo and missing import in alexnet

### DIFF
--- a/antspynet/architectures/create_alexnet_model.py
+++ b/antspynet/architectures/create_alexnet_model.py
@@ -8,7 +8,8 @@ from tensorflow.keras.layers import (Input, Lambda, Concatenate, Flatten, Dense,
                                     Conv2D, Conv2DTranspose, MaxPooling2D,
                                     ZeroPadding2D,
                                     Conv3D, Conv3DTranspose, MaxPooling3D,
-                                    ZeroPadding3D)
+                                    ZeroPadding3D,
+                                    Dropout)
 
 def create_alexnet_model_2d(input_image_size,
                             number_of_classification_labels=1000,
@@ -195,7 +196,7 @@ def create_alexnet_model_2d(input_image_size,
     if mode == 'classification':
         layer_activation = 'softmax'
     elif mode == 'regression':
-        layerActivation = 'linear'
+        layer_activation = 'linear'
     else:
         raise ValueError('unrecognized mode.')
 
@@ -394,7 +395,7 @@ def create_alexnet_model_3d(input_image_size,
     if mode == 'classification':
         layer_activation = 'softmax'
     elif mode == 'regression':
-        layerActivation = 'linear'
+        layer_activation = 'linear'
     else:
         raise ValueError('unrecognized mode.')
 


### PR DESCRIPTION
Alexnet didnt work with mode = 'regression' due to a typo of `layerActivation` instead of `layer_activation`. Also, the Dropout layer was not imported so it errors if you try to use dropout.

On a side note - I found it a bit confusing that the arg is called `number_of_classification_labels` but also applies to regression. Clearly regression is a second-class citizen here ;p 