### PR TITLE
COMP: Update tensorflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy<=1.24.3",
-    "tensorflow>=2.11,<=2.13",
+    "tensorflow>=2.11,<2.16",
     "keras<3",
     "antspyx>=0.4.2",
     "scikit-learn",


### PR DESCRIPTION
This entirely selfish PR is because 2.13 is causing some dependency conflicts for me.

2.16+ requires keras 3, so further updates will not work until keras 3 is supported by antspynet.