### PR TITLE
ENH: Set cache directory with get_antsxnet_cache_directory() function

### DIFF
--- a/antspynet/utilities/__init__.py
+++ b/antspynet/utilities/__init__.py
@@ -1,5 +1,5 @@
 from .get_pretrained_network import get_pretrained_network
-from .get_antsxnet_data import get_antsxnet_data
+from .get_antsxnet_data import get_antsxnet_data, get_antsxnet_cache_directory, set_antsxnet_cache_directory
 
 from .unet_utilities import encode_unet
 from .unet_utilities import decode_unet

--- a/antspynet/utilities/attention_utilities.py
+++ b/antspynet/utilities/attention_utilities.py
@@ -24,7 +24,7 @@ class AttentionLayer2D(Layer):
     number_of_channels : integer
         Number of channels
 
-    Returns
+    Returnsg
     -------
     Layer
         A keras layer

--- a/antspynet/utilities/brain_age.py
+++ b/antspynet/utilities/brain_age.py
@@ -8,7 +8,6 @@ def brain_age(t1,
               do_preprocessing=True,
               number_of_simulations=0,
               sd_affine=0.01,
-              antsxnet_cache_directory=None,
               verbose=False):
 
     """
@@ -42,11 +41,6 @@ def brain_age(t1,
 
     sd_affine : float
         Define the standard deviation of the affine transformation parameter.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -85,7 +79,6 @@ def brain_age(t1,
             template_transform_type="antsRegistrationSyNQuickRepro[a]",
             do_bias_correction=True,
             do_denoising=True,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * t1_preprocessing['brain_mask']
 
@@ -97,7 +90,7 @@ def brain_age(t1,
     #
     ################################
 
-    model_weights_file_name = get_pretrained_network("brainAgeDeepBrainNet", antsxnet_cache_directory=antsxnet_cache_directory)
+    model_weights_file_name = get_pretrained_network("brainAgeDeepBrainNet")
     model = keras.models.load_model(model_weights_file_name)
 
     # The paper only specifies that 80 slices are used for prediction.  I just picked

--- a/antspynet/utilities/cerebellum_morphology.py
+++ b/antspynet/utilities/cerebellum_morphology.py
@@ -5,7 +5,6 @@ def cerebellum_morphology(t1,
                           cerebellum_mask=None,
                           compute_thickness_image=False,
                           do_preprocessing=True,
-                          antsxnet_cache_directory=None,
                           verbose=False
                           ):
 
@@ -66,11 +65,6 @@ def cerebellum_morphology(t1,
     do_preprocessing : boolean
         Perform N4 bias correction and spatiall normalize to template space.
 
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-
     verbose : boolean
         Print progress to the screen.
 
@@ -115,8 +109,7 @@ def cerebellum_morphology(t1,
 
     # spatial priors are in the space of the cerebellar template.  First three are
     # csf, gm, and wm followed by the regions.
-    spatial_priors_file_name_path = get_antsxnet_data("magetCerebellumTemplatePriors",
-        antsxnet_cache_directory=antsxnet_cache_directory)
+    spatial_priors_file_name_path = get_antsxnet_data("magetCerebellumTemplatePriors")
     spatial_priors = ants.image_read(spatial_priors_file_name_path)
     priors_image_list = ants.ndimage_to_list(spatial_priors)
     for i in range(len(priors_image_list)):
@@ -142,8 +135,7 @@ def cerebellum_morphology(t1,
 
     if cerebellum_mask is None:
         # Brain extraction
-        probability_mask = brain_extraction(t1_preprocessed, modality="t1",
-            antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+        probability_mask = brain_extraction(t1_preprocessed, modality="t1", verbose=verbose)
         t1_mask = ants.threshold_image(probability_mask, 0.5, 1, 1, 0)
         t1_brain_preprocessed = t1_preprocessed * t1_mask
 
@@ -242,7 +234,7 @@ def cerebellum_morphology(t1,
         if verbose:
             print("Retrieving model weights.")
 
-        weights_file_name = get_pretrained_network(network_name, antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network(network_name)
         unet_model.load_weights(weights_file_name)
 
         ################################

--- a/antspynet/utilities/chexnet.py
+++ b/antspynet/utilities/chexnet.py
@@ -5,12 +5,9 @@ import pandas as pd
 
 import tensorflow as tf
 
-def check_xray_lung_orientation(image,
-                                antsxnet_cache_directory=None,
-                                verbose=False):
-
+def check_xray_lung_orientation(image, verbose=False):
     """
-    Check the correctness of image orientation, i.e., flipped left-right, up-down, 
+    Check the correctness of image orientation, i.e., flipped left-right, up-down,
     or both.  If True, attempts to correct before returning corrected image.  Otherwise
     it returns None.
 
@@ -19,11 +16,6 @@ def check_xray_lung_orientation(image,
     image : ANTsImage
         2-D X-ray image.
 
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-          
     verbose : boolean
         Print progress to the screen.
 
@@ -48,9 +40,9 @@ def check_xray_lung_orientation(image,
     if image.shape != resampled_image_size:
         if verbose:
             print("Resampling image to", resampled_image_size)
-        resampled_image = ants.resample_image(image, resampled_image_size, use_voxels=True)        
+        resampled_image = ants.resample_image(image, resampled_image_size, use_voxels=True)
     else:
-        resampled_image = ants.image_clone(image)    
+        resampled_image = ants.image_clone(image)
 
     model = create_resnet_model_2d((None, None, 1),
                                     number_of_outputs=3,
@@ -58,15 +50,14 @@ def check_xray_lung_orientation(image,
                                     layers=(1, 2, 3, 4),
                                     residual_block_schedule=(2, 2, 2, 2), lowest_resolution=64,
                                     cardinality=1, squeeze_and_excite=False)
-    weights_file_name = get_pretrained_network("xrayLungOrientation",
-                                                antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("xrayLungOrientation")
     model.load_weights(weights_file_name)
 
     image_min = resampled_image.min()
     image_max = resampled_image.max()
     normalized_image = ants.image_clone(resampled_image)
     normalized_image = (normalized_image - image_min) / (image_max - image_min)
-    
+
     batchX = np.expand_dims(normalized_image.numpy(), 0)
     batchX = np.expand_dims(batchX, -1)
     batchY = model.predict(batchX, verbose=verbose)
@@ -74,24 +65,24 @@ def check_xray_lung_orientation(image,
     # batchY is a 3-element array:
     #   batchY[0] = Pr(image is correctly oriented)
     #   batchY[1] = Pr(image is flipped up/down)
-    #   batchY[2] = Pr(image is flipped left/right)        
+    #   batchY[2] = Pr(image is flipped left/right)
 
     if batchY[0][0] > 0.5:
         return None
     else:
         if verbose:
             print("Possible incorrect orientation.  Attempting to correct.")
-        image_up_down = ants.from_numpy(np.fliplr(normalized_image.numpy()), 
-                                        origin=resampled_image.origin, 
-                                        spacing=resampled_image.spacing, 
+        image_up_down = ants.from_numpy(np.fliplr(normalized_image.numpy()),
+                                        origin=resampled_image.origin,
+                                        spacing=resampled_image.spacing,
                                         direction=resampled_image.direction)
-        image_left_right = ants.from_numpy(np.flipud(normalized_image.numpy()), 
-                                           origin=resampled_image.origin, 
-                                           spacing=resampled_image.spacing, 
+        image_left_right = ants.from_numpy(np.flipud(normalized_image.numpy()),
+                                           origin=resampled_image.origin,
+                                           spacing=resampled_image.spacing,
                                            direction=resampled_image.direction)
-        image_both = ants.from_numpy(np.fliplr(np.flipud(normalized_image.numpy())), 
-                                     origin=resampled_image.origin, 
-                                     spacing=resampled_image.spacing, 
+        image_both = ants.from_numpy(np.fliplr(np.flipud(normalized_image.numpy())),
+                                     origin=resampled_image.origin,
+                                     spacing=resampled_image.spacing,
                                      direction=resampled_image.direction)
 
         batchX = np.zeros((3, *resampled_image_size, 1))
@@ -99,30 +90,30 @@ def check_xray_lung_orientation(image,
         batchX[1,:,:,0] = image_left_right.numpy()
         batchX[2,:,:,0] = image_both.numpy()
         batchY = model.predict(batchX, verbose=verbose)
-        
+
         oriented_image = None
         if batchY[0][0] > batchY[1][0] and batchY[0][0] > batchY[2][0]:
             if verbose:
                 print("Image is flipped up-down.")
-            oriented_image = ants.from_numpy(np.fliplr(image.numpy()), 
-                                             origin=image.origin, 
-                                             spacing=image.spacing, 
+            oriented_image = ants.from_numpy(np.fliplr(image.numpy()),
+                                             origin=image.origin,
+                                             spacing=image.spacing,
                                              direction=image.direction)
-        elif batchY[1][0] > batchY[0][0] and batchY[1][0] > batchY[2][0]:    
+        elif batchY[1][0] > batchY[0][0] and batchY[1][0] > batchY[2][0]:
             if verbose:
                 print("Image is flipped left-right.")
-            oriented_image = ants.from_numpy(np.flipud(image.numpy()), 
-                                             origin=image.origin, 
-                                             spacing=image.spacing, 
+            oriented_image = ants.from_numpy(np.flipud(image.numpy()),
+                                             origin=image.origin,
+                                             spacing=image.spacing,
                                              direction=image.direction)
-        else:    
+        else:
             if verbose:
                 print("Image is flipped up-down and left-right.")
-            oriented_image = ants.from_numpy(np.fliplr(np.flipud(image.numpy())), 
-                                             origin=image.origin, 
-                                             spacing=image.spacing, 
+            oriented_image = ants.from_numpy(np.fliplr(np.flipud(image.numpy())),
+                                             origin=image.origin,
+                                             spacing=image.spacing,
                                              direction=image.direction)
-        return oriented_image         
+        return oriented_image
 
 
 def chexnet(image,
@@ -130,18 +121,17 @@ def chexnet(image,
             check_image_orientation=False,
             use_antsxnet_variant=True,
             include_tuberculosis_diagnosis=False,
-            antsxnet_cache_directory=None,
             verbose=False):
 
     """
     ANTsXNet reproduction of https://arxiv.org/pdf/1711.05225.pdf.  This includes
     our own network architecture and training (including data augmentation).
-    
+
     "CheXNet: Radiologist-Level Pneumonia Detection on Chest X-Rays with Deep Learning"
 
     Includes a network for checking the correctness of image orientation, i.e.,
     flipped left-right, up-down, or both.
-    
+
     Disease categories:
        Atelectasis
        Cardiomegaly
@@ -149,7 +139,7 @@ def chexnet(image,
        Edema
        Effusion
        Emphysema
-       Fibrosis 
+       Fibrosis
        Hernia
        Infiltration
        Mass
@@ -166,25 +156,20 @@ def chexnet(image,
 
     lung_mask : ANTsImage
         Lung mask.  If None is specified, one is estimated.
-        
+
     check_image_orientation : boolean
-        Check the correctness of image orientation, i.e., flipped left-right, up-down, 
+        Check the correctness of image orientation, i.e., flipped left-right, up-down,
         or both.  If True, attempts to correct before prediction.
-        
+
     use_antsxnet_variant : boolean
         Use an extension of the original chexnet approach by adding a left/right
         lung masking and including those two masked regions in the red and green
-        channels, respectively. 
+        channels, respectively.
 
     include_tuberculosis_diagnosis : boolean
         Include the output of an additional network trained on TB data but using
         the ANTsXNet variant chexnet data as the initial weights.
-         
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-          
+
     verbose : boolean
         Print progress to the screen.
 
@@ -233,28 +218,26 @@ def chexnet(image,
     if image.shape != image_size:
         if verbose:
             print("Resampling image to", image_size)
-        resampled_image = ants.resample_image(image, image_size, use_voxels=True)      
-         
+        resampled_image = ants.resample_image(image, image_size, use_voxels=True)
+
     if lung_mask is None:
         if verbose:
             print("No lung mask provided.  Estimating using antsxnet.")
-        lung_extract = lung_extraction(image, modality="xray", 
-                                       antsxnet_cache_directory=antsxnet_cache_directory, 
-                                       verbose=verbose)
+        lung_extract = lung_extraction(image, modality="xray", verbose=verbose)
         lung_mask = lung_extract['segmentation_image']
 
     if lung_mask.shape != image_size:
         resampled_lung_mask = ants.resample_image(lung_mask, image_size, use_voxels=True, interp_type=1)
     else:
-        resampled_lung_mask = ants.image_clone(lung_mask)    
-          
-    model = tf.keras.applications.DenseNet121(include_top=False, 
-                                            weights="imagenet", 
-                                            input_tensor=None, 
-                                            input_shape=(224, 224, 3), 
+        resampled_lung_mask = ants.image_clone(lung_mask)
+
+    model = tf.keras.applications.DenseNet121(include_top=False,
+                                            weights="imagenet",
+                                            input_tensor=None,
+                                            input_shape=(224, 224, 3),
                                             pooling='avg')
     x = tf.keras.layers.Dense(units=len(disease_categories),
-                                activation='sigmoid')(model.output)                                           
+                                activation='sigmoid')(model.output)
     model = tf.keras.Model(inputs=model.input, outputs=x)
 
     # use imagenet mean,std for normalization
@@ -269,8 +252,7 @@ def chexnet(image,
         x = tf.keras.layers.Dense(units=1,
                                   activation='sigmoid')(model.output)
         tb_model = tf.keras.Model(inputs=model.input, outputs=x)
-        weights_file_name = get_pretrained_network("tb_antsxnet",
-                                                   antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("tb_antsxnet")
         tb_model.load_weights(weights_file_name)
 
         batchX = np.zeros((1, *image_size, number_of_channels))
@@ -279,17 +261,16 @@ def chexnet(image,
 
         batchX[0,:,:,0] = (image_array - imagenet_mean[0]) / (imagenet_std[0])
         batchX[0,:,:,1] = (image_array - imagenet_mean[1]) / (imagenet_std[1])
-        batchX[0,:,:,1] *= (ants.threshold_image(resampled_lung_mask, 1, 1, 1, 0)).numpy() 
+        batchX[0,:,:,1] *= (ants.threshold_image(resampled_lung_mask, 1, 1, 1, 0)).numpy()
         batchX[0,:,:,2] = (image_array - imagenet_mean[2]) / (imagenet_std[2])
-        batchX[0,:,:,2] *= (ants.threshold_image(resampled_lung_mask, 2, 2, 1, 0)).numpy() 
-        
+        batchX[0,:,:,2] *= (ants.threshold_image(resampled_lung_mask, 2, 2, 1, 0)).numpy()
+
         batchY = tb_model.predict(batchX, verbose=verbose)
         tb_prediction = batchY[0]
 
     if not use_antsxnet_variant:
 
-        weights_file_name = get_pretrained_network("chexnetClassification",
-                                                   antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("chexnetClassification")
         model.load_weights(weights_file_name)
 
         batchX = np.zeros((1, *image_size, number_of_channels))
@@ -300,15 +281,14 @@ def chexnet(image,
 
         batchY = model.predict(batchX, verbose=verbose)
         disease_category_df = pd.DataFrame(batchY, columns=disease_categories)
-        
+
         if include_tuberculosis_diagnosis:
             disease_category_df['Tuberculosis'] = tb_prediction
         return disease_category_df
 
     else:
 
-        weights_file_name = get_pretrained_network("chexnetANTsXNetClassification",
-                                                   antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("chexnetANTsXNetClassification")
 
         model.load_weights(weights_file_name)
 
@@ -318,10 +298,10 @@ def chexnet(image,
 
         batchX[0,:,:,0] = (image_array - imagenet_mean[0]) / (imagenet_std[0])
         batchX[0,:,:,1] = (image_array - imagenet_mean[1]) / (imagenet_std[1])
-        batchX[0,:,:,1] *= (ants.threshold_image(resampled_lung_mask, 1, 1, 1, 0)).numpy() 
+        batchX[0,:,:,1] *= (ants.threshold_image(resampled_lung_mask, 1, 1, 1, 0)).numpy()
         batchX[0,:,:,2] = (image_array - imagenet_mean[2]) / (imagenet_std[2])
-        batchX[0,:,:,2] *= (ants.threshold_image(resampled_lung_mask, 2, 2, 1, 0)).numpy() 
-        
+        batchX[0,:,:,2] *= (ants.threshold_image(resampled_lung_mask, 2, 2, 1, 0)).numpy()
+
         batchY = model.predict(batchX, verbose=verbose)
         disease_category_df = pd.DataFrame(batchY, columns=disease_categories)
 

--- a/antspynet/utilities/claustrum_segmentation.py
+++ b/antspynet/utilities/claustrum_segmentation.py
@@ -5,7 +5,6 @@ import ants
 def claustrum_segmentation(t1,
                            do_preprocessing=True,
                            use_ensemble=True,
-                           antsxnet_cache_directory=None,
                            verbose=False):
 
     """
@@ -30,11 +29,6 @@ def claustrum_segmentation(t1,
 
     use_ensemble : boolean
         check whether to use all 3 sets of weights.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -75,7 +69,6 @@ def claustrum_segmentation(t1,
             brain_extraction_modality="t1",
             do_bias_correction=True,
             do_denoising=True,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"]
         brain_mask = t1_preprocessing["brain_mask"]
@@ -121,7 +114,7 @@ def claustrum_segmentation(t1,
 
     unet_axial_models = list()
     for i in range(number_of_models):
-        weights_file_name = get_pretrained_network("claustrum_axial_" + str(i), antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("claustrum_axial_" + str(i))
         unet_axial_models.append(create_sysu_media_unet_model_2d((*image_size, number_of_channels), anatomy="claustrum"))
         unet_axial_models[i].load_weights(weights_file_name)
 
@@ -130,7 +123,7 @@ def claustrum_segmentation(t1,
 
     unet_coronal_models = list()
     for i in range(number_of_models):
-        weights_file_name = get_pretrained_network("claustrum_coronal_" + str(i), antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("claustrum_coronal_" + str(i))
         unet_coronal_models.append(create_sysu_media_unet_model_2d((*image_size, number_of_channels), anatomy="claustrum"))
         unet_coronal_models[i].load_weights(weights_file_name)
 

--- a/antspynet/utilities/cortical_thickness.py
+++ b/antspynet/utilities/cortical_thickness.py
@@ -2,9 +2,7 @@ import numpy as np
 import tensorflow as tf
 import ants
 
-def cortical_thickness(t1,
-                       antsxnet_cache_directory=None,
-                       verbose=False):
+def cortical_thickness(t1, verbose=False):
 
     """
     Perform KellyKapowski cortical thickness using deep_atropos for
@@ -16,11 +14,6 @@ def cortical_thickness(t1,
     ---------
     t1 : ANTsImage
         input 3-D unprocessed T1-weighted brain image.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -40,8 +33,7 @@ def cortical_thickness(t1,
     if t1.dimension != 3:
         raise ValueError("Image dimension must be 3.")
 
-    atropos = deep_atropos(t1, do_preprocessing=True,
-        antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+    atropos = deep_atropos(t1, do_preprocessing=True, verbose=verbose)
 
     # Kelly Kapowski cortical thickness
 
@@ -68,7 +60,6 @@ def longitudinal_cortical_thickness(t1s,
                                     initial_template="oasis",
                                     number_of_iterations=1,
                                     refinement_transform="antsRegistrationSyNQuick[a]",
-                                    antsxnet_cache_directory=None,
                                     verbose=False):
 
     """
@@ -94,11 +85,6 @@ def longitudinal_cortical_thickness(t1s,
     refinement_transform : string
        Transform for defining the refinement registration transform. See options in
        ants.registration.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -126,7 +112,7 @@ def longitudinal_cortical_thickness(t1s,
 
     sst = None
     if isinstance(initial_template, str):
-        template_file_name_path = get_antsxnet_data(initial_template, antsxnet_cache_directory=antsxnet_cache_directory)
+        template_file_name_path = get_antsxnet_data(initial_template)
         sst = ants.image_read(template_file_name_path)
     else:
         sst = initial_template
@@ -152,7 +138,6 @@ def longitudinal_cortical_thickness(t1s,
                 do_bias_correction=False,
                 do_denoising=False,
                 intensity_normalization_type="01",
-                antsxnet_cache_directory=antsxnet_cache_directory,
                 verbose=verbose)
             sst_tmp += t1_preprocessed['preprocessed_image']
 
@@ -178,7 +163,6 @@ def longitudinal_cortical_thickness(t1s,
             do_bias_correction=True,
             do_denoising=True,
             intensity_normalization_type="01",
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1s_preprocessed.append(t1_preprocessed)
 
@@ -188,8 +172,7 @@ def longitudinal_cortical_thickness(t1s,
     #
     ##################
 
-    sst_atropos = deep_atropos(sst, do_preprocessing=True,
-        antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+    sst_atropos = deep_atropos(sst, do_preprocessing=True, verbose=verbose)
 
     ###################
     #

--- a/antspynet/utilities/deep_flash.py
+++ b/antspynet/utilities/deep_flash.py
@@ -10,7 +10,6 @@ def deep_flash(t1,
                which_parcellation="yassa",
                do_preprocessing=True,
                use_rank_intensity=True,
-               antsxnet_cache_directory=None,
                verbose=False
                ):
 
@@ -38,7 +37,7 @@ def deep_flash(t1,
     Label 16:  right CA1
     Label 17:  left subiculum
     Label 18:  right subiculum
-        
+
     Preprocessing on the training data consisted of:
        * n4 bias correction,
        * affine registration to the "deep flash" template.
@@ -50,9 +49,9 @@ def deep_flash(t1,
         raw or preprocessed 3-D T1-weighted brain image.
 
     t2 : ANTsImage
-        Optional 3-D T2-weighted brain image for yassa parcellation.  If 
+        Optional 3-D T2-weighted brain image for yassa parcellation.  If
         specified, it is assumed to be pre-aligned to the t1.
-        
+
     which_parcellation : string --- "yassa"
         See above label descriptions.
 
@@ -63,11 +62,6 @@ def deep_flash(t1,
         If false, use histogram matching with cropped template ROI.  Otherwise,
         use a rank intensity transform on the cropped ROI.  Only for "yassa"
         parcellation.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -128,8 +122,7 @@ def deep_flash(t1,
                 print("Preprocessing T1.")
 
             # Brain extraction
-            probability_mask = brain_extraction(t1_preprocessed, modality="t1",
-                antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+            probability_mask = brain_extraction(t1_preprocessed, modality="t1", verbose=verbose)
             t1_mask = ants.threshold_image(probability_mask, 0.5, 1, 1, 0)
             t1_preprocessed = t1_preprocessed * t1_mask
 
@@ -197,8 +190,7 @@ def deep_flash(t1,
         #
         ################################
 
-        spatial_priors_file_name_path = get_antsxnet_data("deepFlashPriors",
-            antsxnet_cache_directory=antsxnet_cache_directory)
+        spatial_priors_file_name_path = get_antsxnet_data("deepFlashPriors")
         spatial_priors = ants.image_read(spatial_priors_file_name_path)
         priors_image_list = ants.ndimage_to_list(spatial_priors)
         for i in range(len(priors_image_list)):
@@ -302,7 +294,7 @@ def deep_flash(t1,
 
         if verbose:
             print("DeepFlash: retrieving model weights (left).")
-        weights_file_name = get_pretrained_network(network_name, antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network(network_name)
         unet_model.load_weights(weights_file_name)
 
         ################################
@@ -431,7 +423,7 @@ def deep_flash(t1,
 
         if verbose:
             print("DeepFlash: retrieving model weights (right).")
-        weights_file_name = get_pretrained_network(network_name, antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network(network_name)
         unet_model.load_weights(weights_file_name)
 
         ################################
@@ -629,8 +621,7 @@ def deep_flash(t1,
                 print("Preprocessing T1.")
 
             # Brain extraction
-            probability_mask = brain_extraction(t1_preprocessed, modality="t1",
-                antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+            probability_mask = brain_extraction(t1_preprocessed, modality="t1", verbose=verbose)
             t1_mask = ants.threshold_image(probability_mask, 0.5, 1, 1, 0)
             t1_preprocessed = t1_preprocessed * t1_mask
 
@@ -657,9 +648,9 @@ def deep_flash(t1,
         labels_left = list((104, 105, 106, 108, 109, 110, 114, 115, 126, 6001, 6003, 6008, 6009, 6010))
         labels_right = list((204, 205, 206, 208, 209, 210, 214, 215, 226, 7001, 7003, 7008, 7009, 7010))
 
-        # labels_left = list((103, 104, 105, 106, 108, 109, 110, 111, 112, 114, 115, 126, 
+        # labels_left = list((103, 104, 105, 106, 108, 109, 110, 111, 112, 114, 115, 126,
         #                     6001, 6003, 6005, 6006, 6007, 6008, 6009, 6010, 6015))
-        # labels_right = list((203, 204, 205, 206, 208, 209, 210, 211, 212, 214, 215, 226, 
+        # labels_right = list((203, 204, 205, 206, 208, 209, 210, 211, 212, 214, 215, 226,
         #                     7001, 7003, 7005, 7006, 7007, 7008, 7009, 7010, 7015))
         labels = np.array(np.repeat(0, 1 + len(labels_left) + len(labels_right)))
         labels[1::2] = labels_left
@@ -678,8 +669,7 @@ def deep_flash(t1,
         #
         ################################
 
-        prior_labels_file_name_path = get_antsxnet_data("deepFlashTemplate2Labels",
-            antsxnet_cache_directory=antsxnet_cache_directory)
+        prior_labels_file_name_path = get_antsxnet_data("deepFlashTemplate2Labels")
         prior_labels = ants.image_read(prior_labels_file_name_path)
 
         priors_image_left_list = list()
@@ -705,7 +695,7 @@ def deep_flash(t1,
         direction = tmp_cropped.direction
 
         t1_template_roi_left = ants.crop_indices(t1_template, lower_bound_left, upper_bound_left)
-        t1_template_roi_left = ((t1_template_roi_left - t1_template_roi_left.min()) / 
+        t1_template_roi_left = ((t1_template_roi_left - t1_template_roi_left.min()) /
                                 (t1_template_roi_left.max() - t1_template_roi_left.min()) * 2.0 - 1.0)
 
         probability_images_right = list()
@@ -716,7 +706,7 @@ def deep_flash(t1,
         origin_right = tmp_cropped.origin
 
         t1_template_roi_right = ants.crop_indices(t1_template, lower_bound_right, upper_bound_right)
-        t1_template_roi_right = ((t1_template_roi_right - t1_template_roi_right.min()) / 
+        t1_template_roi_right = ((t1_template_roi_right - t1_template_roi_right.min()) /
                                  (t1_template_roi_right.max() - t1_template_roi_right.min()) * 2.0 - 1.0)
 
         ################################
@@ -767,7 +757,7 @@ def deep_flash(t1,
 
         if verbose:
             print("DeepFlash: retrieving model weights (left).")
-        weights_file_name = get_pretrained_network(network_name, antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network(network_name)
         unet_model.load_weights(weights_file_name)
 
         ################################
@@ -869,7 +859,7 @@ def deep_flash(t1,
 
         if verbose:
             print("DeepFlash: retrieving model weights (right).")
-        weights_file_name = get_pretrained_network(network_name, antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network(network_name)
         unet_model.load_weights(weights_file_name)
 
         ################################
@@ -1018,5 +1008,5 @@ def deep_flash(t1,
                         }
         return(return_dict)
 
-    else: 
+    else:
         raise ValueError("Unrecognized parcellation.")

--- a/antspynet/utilities/desikan_killiany_tourville_labeling.py
+++ b/antspynet/utilities/desikan_killiany_tourville_labeling.py
@@ -6,7 +6,6 @@ def desikan_killiany_tourville_labeling(t1,
                                         do_preprocessing=True,
                                         return_probability_images=False,
                                         do_lobar_parcellation=False,
-                                        antsxnet_cache_directory=None,
                                         verbose=False):
 
     """
@@ -223,11 +222,6 @@ def desikan_killiany_tourville_labeling(t1,
     do_lobar_parcellation : boolean
         Perform lobar parcellation (also divided by hemisphere).
 
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-
     verbose : boolean
         Print progress to the screen.
 
@@ -267,7 +261,6 @@ def desikan_killiany_tourville_labeling(t1,
             template_transform_type=template_transform_type,
             do_bias_correction=True,
             do_denoising=True,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * t1_preprocessing['brain_mask']
 
@@ -277,8 +270,7 @@ def desikan_killiany_tourville_labeling(t1,
     #
     ################################
 
-    spatial_priors_file_name_path = get_antsxnet_data("priorDktLabels",
-      antsxnet_cache_directory=antsxnet_cache_directory)
+    spatial_priors_file_name_path = get_antsxnet_data("priorDktLabels")
     spatial_priors = ants.image_read(spatial_priors_file_name_path)
     priors_image_list = ants.ndimage_to_list(spatial_priors)
 
@@ -300,8 +292,7 @@ def desikan_killiany_tourville_labeling(t1,
         weight_decay = 1e-5, additional_options=("attentionGating"))
 
     weights_file_name = None
-    weights_file_name = get_pretrained_network("dktOuterWithSpatialPriors",
-                                               antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("dktOuterWithSpatialPriors")
     unet_model.load_weights(weights_file_name)
 
     ################################
@@ -369,7 +360,7 @@ def desikan_killiany_tourville_labeling(t1,
         convolution_kernel_size = (3, 3, 3), deconvolution_kernel_size = (2, 2, 2),
         weight_decay = 1e-5, additional_options=("attentionGating"))
 
-    weights_file_name = get_pretrained_network("dktInner", antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("dktInner")
     unet_model.load_weights(weights_file_name)
 
     ################################
@@ -467,8 +458,7 @@ def desikan_killiany_tourville_labeling(t1,
 
         dkt_lobes[dkt_lobes > len(lobar_labels)] = 0
 
-        six_tissue = deep_atropos(t1_preprocessed, do_preprocessing=False,
-            antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+        six_tissue = deep_atropos(t1_preprocessed, do_preprocessing=False, verbose=verbose)
         atropos_seg = six_tissue['segmentation_image']
         if do_preprocessing:
             atropos_seg = ants.apply_transforms(fixed=t1, moving=atropos_seg,

--- a/antspynet/utilities/get_antsxnet_data.py
+++ b/antspynet/utilities/get_antsxnet_data.py
@@ -29,7 +29,7 @@ def set_antsxnet_cache_directory(antsxnet_cache_dir):
         The directory to store ANTsXNet data. It will be created if it does not exist.
     """
     global _antsxnet_cache_directory
-    _antsxnet_cache_directory = antsxnet_cache_dir
+    _antsxnet_cache_directory = os.path.abspath(antsxnet_cache_dir)
 
     if not os.path.exists(_antsxnet_cache_directory):
         os.makedirs(_antsxnet_cache_directory)

--- a/antspynet/utilities/get_antsxnet_data.py
+++ b/antspynet/utilities/get_antsxnet_data.py
@@ -2,9 +2,41 @@ import tensorflow as tf
 import ants
 import os.path
 
+_antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
+
+def get_antsxnet_cache_directory():
+    """Get the cache directory for ANTsXNet data. Data and pre-trained models will be
+    downloaded here.
+
+    The default directory is ~/.keras/ANTsXNet.
+
+    Returns
+    -------
+    antsxnet_cache_directory string
+        The directory to store ANTsXNet data.
+
+    """
+    return(_antsxnet_cache_directory)
+
+
+def set_antsxnet_cache_directory(antsxnet_cache_dir):
+    """Set the cache directory for ANTsXNet data. Data and pre-trained models will be
+    downloaded here.
+
+    Arguments
+    ---------
+    antsxnet_cache_dir string
+        The directory to store ANTsXNet data. It will be created if it does not exist.
+    """
+    global _antsxnet_cache_directory
+    _antsxnet_cache_directory = antsxnet_cache_dir
+
+    if not os.path.exists(_antsxnet_cache_directory):
+        os.makedirs(_antsxnet_cache_directory)
+
+
 def get_antsxnet_data(file_id=None,
-                      target_file_name=None,
-                      antsxnet_cache_directory=None):
+                      target_file_name=None):
 
     """
     Download data such as prefabricated templates and spatial priors.
@@ -19,10 +51,6 @@ def get_antsxnet_data(file_id=None,
 
     target_file_name string
        Optional target filename.
-
-    antsxnet_cache_directory string
-       Optional target output.  If not specified these data will be downloaded
-       to the subdirectory ~/.keras/ANTsXNet/.
 
     Returns
     -------
@@ -151,10 +179,7 @@ def get_antsxnet_data(file_id=None,
         else:
             target_file_name = file_id + ".nii.gz"
 
-    if antsxnet_cache_directory is None:
-        antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
-
-    target_file_name_path = os.path.join(antsxnet_cache_directory, target_file_name)
+    target_file_name_path = os.path.join(get_antsxnet_cache_directory(), target_file_name)
 
     # keras get_file does not work on read-only file systems. It will attempt to download the file even
     # if it exists. This is a problem for shared cache directories and read-only containers.
@@ -166,6 +191,6 @@ def get_antsxnet_data(file_id=None,
             raise NotImplementedError(err_msg)
 
         target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
-                                                        cache_subdir=antsxnet_cache_directory)
+                                                        cache_subdir=get_antsxnet_cache_directory())
 
     return(target_file_name_path)

--- a/antspynet/utilities/get_antsxnet_data.py
+++ b/antspynet/utilities/get_antsxnet_data.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import ants
 import os.path
 
-_antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
+_antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), '.keras', 'ANTsXNet')
 
 def get_antsxnet_cache_directory():
     """Get the cache directory for ANTsXNet data. Data and pre-trained models will be

--- a/antspynet/utilities/get_pretrained_network.py
+++ b/antspynet/utilities/get_pretrained_network.py
@@ -1,9 +1,10 @@
 import os.path
 import tensorflow as tf
 
+from antspynet.utilities.get_antsxnet_data import get_antsxnet_cache_directory
+
 def get_pretrained_network(file_id=None,
-                           target_file_name=None,
-                           antsxnet_cache_directory=None):
+                           target_file_name=None):
 
     """
     Download pretrained network/weights.
@@ -18,10 +19,6 @@ def get_pretrained_network(file_id=None,
 
     target_file_name string
        Optional target filename.
-
-    antsxnet_cache_directory string
-       Optional target output.  If not specified these data will be downloaded
-       to the subdirectory ~/.keras/ANTsXNet/.
 
     Returns
     -------
@@ -335,10 +332,7 @@ def get_pretrained_network(file_id=None,
     if target_file_name is None:
         target_file_name = file_id + ".h5"
 
-    if antsxnet_cache_directory is None:
-        antsxnet_cache_directory = os.path.join(os.path.expanduser('~'), ".keras/ANTsXNet")
-
-    target_file_name_path = os.path.join(antsxnet_cache_directory, target_file_name)
+    target_file_name_path = os.path.join(get_antsxnet_cache_directory(), target_file_name)
 
     # keras get_file does not work on read-only file systems. It will attempt to download the file even
     # if it exists. This is a problem for shared cache directories and read-only containers.
@@ -350,6 +344,6 @@ def get_pretrained_network(file_id=None,
             raise NotImplementedError(err_msg)
 
         target_file_name_path = tf.keras.utils.get_file(target_file_name, url,
-                                                        cache_subdir=antsxnet_cache_directory)
+                                                        cache_subdir=get_antsxnet_cache_directory())
 
     return(target_file_name_path)

--- a/antspynet/utilities/hippmapp3r_segmentation.py
+++ b/antspynet/utilities/hippmapp3r_segmentation.py
@@ -4,7 +4,6 @@ import ants
 
 def hippmapp3r_segmentation(t1,
                             do_preprocessing=True,
-                            antsxnet_cache_directory=None,
                             verbose=False):
 
     """
@@ -34,11 +33,6 @@ def hippmapp3r_segmentation(t1,
 
     do_preprocessing : boolean
         See description above.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -72,7 +66,6 @@ def hippmapp3r_segmentation(t1,
             template=None,
             do_bias_correction=True,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * t1_preprocessing['brain_mask']
 
@@ -84,7 +77,7 @@ def hippmapp3r_segmentation(t1,
     if verbose == True:
         print("    HippMapp3r: template normalization.")
 
-    template_file_name_path = get_antsxnet_data("mprage_hippmapp3r", antsxnet_cache_directory=antsxnet_cache_directory)
+    template_file_name_path = get_antsxnet_data("mprage_hippmapp3r")
     template_image = ants.image_read(template_file_name_path)
 
     registration = ants.registration(fixed=template_image, moving=t1_preprocessed,
@@ -125,7 +118,7 @@ def hippmapp3r_segmentation(t1,
 
     model_initial_stage = create_hippmapp3r_unet_model_3d((*shape_initial_stage, 1), do_first_network=True)
 
-    initial_stage_weights_file_name = get_pretrained_network("hippMapp3rInitial", antsxnet_cache_directory=antsxnet_cache_directory)
+    initial_stage_weights_file_name = get_pretrained_network("hippMapp3rInitial")
     model_initial_stage.load_weights(initial_stage_weights_file_name)
 
     if verbose == True:
@@ -168,7 +161,7 @@ def hippmapp3r_segmentation(t1,
 
     model_refine_stage = create_hippmapp3r_unet_model_3d((*shape_refine_stage, 1), do_first_network=False)
 
-    refine_stage_weights_file_name = get_pretrained_network("hippMapp3rRefine", antsxnet_cache_directory=antsxnet_cache_directory)
+    refine_stage_weights_file_name = get_pretrained_network("hippMapp3rRefine")
     model_refine_stage.load_weights(refine_stage_weights_file_name)
 
     data_refine_stage = np.expand_dims(image_trimmed.numpy(), axis=0)

--- a/antspynet/utilities/histology.py
+++ b/antspynet/utilities/histology.py
@@ -3,7 +3,6 @@ import ants
 import warnings
 
 def arterial_lesion_segmentation(image,
-                                 antsxnet_cache_directory=None,
                                  verbose=False):
 
     """
@@ -13,11 +12,6 @@ def arterial_lesion_segmentation(image,
     ---------
     image : ANTsImage
         input image
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -39,8 +33,7 @@ def arterial_lesion_segmentation(image,
 
     channel_size = 1
 
-    weights_file_name = get_pretrained_network("arterialLesionWeibinShi",
-        antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("arterialLesionWeibinShi")
 
     resampled_image_size = (512, 512)
 

--- a/antspynet/utilities/hypothalamus_segmentation.py
+++ b/antspynet/utilities/hypothalamus_segmentation.py
@@ -3,7 +3,6 @@ import numpy as np
 import ants
 
 def hypothalamus_segmentation(t1,
-                              antsxnet_cache_directory=None,
                               verbose=False):
 
     """
@@ -34,11 +33,6 @@ def hypothalamus_segmentation(t1,
     ---------
     t1 : ANTsImage
         input 3-D T1 brain image.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -114,7 +108,7 @@ def hypothalamus_segmentation(t1,
 
     unet_model = create_hypothalamus_unet_model_3d(t1_warped.shape)
 
-    weights_file_name = get_pretrained_network("hypothalamus", antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("hypothalamus")
     unet_model.load_weights(weights_file_name)
 
     ################################

--- a/antspynet/utilities/mri_modality_classification.py
+++ b/antspynet/utilities/mri_modality_classification.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 def mri_modality_classification(image,
-                                antsxnet_cache_directory=None,
                                 verbose=False):
 
     """
@@ -24,11 +23,7 @@ def mri_modality_classification(image,
     image : ANTsImage
         raw 3-D MRI whole head image.
 
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-        
+
     verbose : boolean
         Print progress to the screen.
 
@@ -83,8 +78,7 @@ def mri_modality_classification(image,
     #
     ################################
 
-    weights_file_name = get_pretrained_network("mriModalityClassification",
-                                               antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("mriModalityClassification")
 
     modality_types = ["T1", "T2", "FLAIR", "T2Star", "Mean DWI", "Mean Bold", "ASL Perfusion"]
 

--- a/antspynet/utilities/mri_super_resolution.py
+++ b/antspynet/utilities/mri_super_resolution.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 import ants
 
 
-def mri_super_resolution(image, antsxnet_cache_directory=None, verbose=False):
+def mri_super_resolution(image, verbose=False):
 
     """
     Perform super-resolution (2x) of MRI data using deep back projection network.
@@ -12,11 +12,6 @@ def mri_super_resolution(image, antsxnet_cache_directory=None, verbose=False):
     ---------
     image : ANTsImage
         magnetic resonance image
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -38,7 +33,7 @@ def mri_super_resolution(image, antsxnet_cache_directory=None, verbose=False):
     if image.dimension != 3:
         raise ValueError("Image dimension must be 3.")
 
-    model_and_weights_file_name = get_pretrained_network("mriSuperResolution", antsxnet_cache_directory=antsxnet_cache_directory)
+    model_and_weights_file_name = get_pretrained_network("mriSuperResolution")
     model_sr = tf.keras.models.load_model(model_and_weights_file_name, compile=False)
 
     image_sr = apply_super_resolution_model_to_image(

--- a/antspynet/utilities/preprocess_image.py
+++ b/antspynet/utilities/preprocess_image.py
@@ -13,7 +13,6 @@ def preprocess_brain_image(image,
                            intensity_matching_type=None,
                            reference_image=None,
                            intensity_normalization_type=None,
-                           antsxnet_cache_directory=None,
                            verbose=True):
 
     """
@@ -66,11 +65,6 @@ def preprocess_brain_image(image,
         Either rescale the intensities to [0,1] (i.e., "01") or zero-mean, unit variance
         (i.e., "0mean").  If None normalization is not performed.
 
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
-
     verbose : boolean
         Print progress to the screen.
 
@@ -107,8 +101,7 @@ def preprocess_brain_image(image,
         if verbose == True:
             print("Preprocessing:  brain extraction.")
 
-        probability_mask = brain_extraction(preprocessed_image, modality=brain_extraction_modality,
-            antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+        probability_mask = brain_extraction(preprocessed_image, modality=brain_extraction_modality, verbose=verbose)
         mask = ants.threshold_image(probability_mask, 0.5, 1, 1, 0)
         mask = ants.morphology(mask,"close",6).iMath_fill_holes()
 
@@ -117,7 +110,7 @@ def preprocess_brain_image(image,
     if template_transform_type is not None:
         template_image = None
         if isinstance(template, str):
-            template_file_name_path = get_antsxnet_data(template, antsxnet_cache_directory=antsxnet_cache_directory)
+            template_file_name_path = get_antsxnet_data(template)
             template_image = ants.image_read(template_file_name_path)
         else:
             template_image = template
@@ -129,8 +122,7 @@ def preprocess_brain_image(image,
             transforms = dict(fwdtransforms=registration['fwdtransforms'],
                               invtransforms=registration['invtransforms'])
         else:
-            template_probability_mask = brain_extraction(template_image, modality=brain_extraction_modality,
-                antsxnet_cache_directory=antsxnet_cache_directory, verbose=verbose)
+            template_probability_mask = brain_extraction(template_image, modality=brain_extraction_modality, verbose=verbose)
             template_mask = ants.threshold_image(template_probability_mask, 0.5, 1, 1, 0)
             template_brain_image = template_mask * template_image
 

--- a/antspynet/utilities/quality_assessment.py
+++ b/antspynet/utilities/quality_assessment.py
@@ -42,7 +42,6 @@ def tid_neural_image_assessment(image,
                                 stride_length=None,
                                 padding_size=0,
                                 dimensions_to_predict=0,
-                                antsxnet_cache_directory=None,
                                 which_model="tidsQualityAssessment",
                                 image_scaling = [255,127.5],
                                 do_patch_scaling=False,
@@ -89,11 +88,6 @@ def tid_neural_image_assessment(image,
     dimensions_to_predict : integer or vector
         if image dimension is 3, this parameter specifies which dimensions should be used for
         prediction.  If more than one dimension is specified, the results are averaged.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to
-        ~/.keras/ANTsXNet/.
 
     which_model : string or tf/keras model
         model type e.g. string tidsQualityAssessment, koniqMS, koniqMS2 or koniqMS3 where
@@ -165,7 +159,7 @@ def tid_neural_image_assessment(image,
 
     is_koniq = "koniq" in which_model
     if which_model != "user_defined":
-        model_and_weights_file_name = get_pretrained_network(which_model, antsxnet_cache_directory=antsxnet_cache_directory)
+        model_and_weights_file_name = get_pretrained_network(which_model)
         tid_model = tf.keras.models.load_model(model_and_weights_file_name, compile=False)
 
     padding_size_vector = padding_size

--- a/antspynet/utilities/ukbb.py
+++ b/antspynet/utilities/ukbb.py
@@ -4,7 +4,6 @@ import tarfile
 def ukbb(image,
          pipeline="All",
          target="Age",
-         antsxnet_cache_directory=None,
          verbose=False):
 
     """
@@ -14,11 +13,6 @@ def ukbb(image,
     ---------
     image : ANTsImage
         input image
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -40,8 +34,7 @@ def ukbb(image,
 
     channel_size = 1
 
-    weights_file_name = get_pretrained_network("arterialLesionWeibinShi",
-        antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("arterialLesionWeibinShi")
 
     resampled_image_size = (512, 512)
 
@@ -86,7 +79,6 @@ def ukbb(image,
 def e13x5_brain_extraction(image,
                            view = "sagittal",
                            which_axis=2,
-                           antsxnet_cache_directory=None,
                            verbose=False):
 
     """
@@ -102,11 +94,6 @@ def e13x5_brain_extraction(image,
 
     which_axis : integer
         If 3-D image, which_axis specifies the direction of the "view".
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -128,11 +115,9 @@ def e13x5_brain_extraction(image,
 
     weights_file_name = ""
     if view.lower() == "coronal":
-        weights_file_name = get_pretrained_network("e13x5_coronal_weights",
-            antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("e13x5_coronal_weights")
     elif view.lower() == "sagittal":
-        weights_file_name = get_pretrained_network("e13x5_sagittal_weights",
-            antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("e13x5_sagittal_weights")
     else:
         raise ValueError("Valid view options are coronal and sagittal.")
 

--- a/antspynet/utilities/white_matter_hyperintensity_segmentation.py
+++ b/antspynet/utilities/white_matter_hyperintensity_segmentation.py
@@ -7,7 +7,6 @@ from tensorflow import keras
 def sysu_media_wmh_segmentation(flair,
                                 t1=None,
                                 use_ensemble=True,
-                                antsxnet_cache_directory=None,
                                 verbose=False):
 
     """
@@ -41,11 +40,6 @@ def sysu_media_wmh_segmentation(flair,
 
     use_ensemble : boolean
         check whether to use all 3 sets of weights.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -89,7 +83,6 @@ def sysu_media_wmh_segmentation(flair,
         brain_extraction_modality=None,
         do_bias_correction=False,
         do_denoising=False,
-        antsxnet_cache_directory=antsxnet_cache_directory,
         verbose=verbose)
     flair_preprocessed = flair_preprocessing["preprocessed_image"]
     flair_preprocessed.set_direction(simplified_direction)
@@ -104,7 +97,6 @@ def sysu_media_wmh_segmentation(flair,
             brain_extraction_modality=None,
             do_bias_correction=False,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"]
         t1_preprocessed.set_direction(simplified_direction)
@@ -172,11 +164,9 @@ def sysu_media_wmh_segmentation(flair,
     unet_models = list()
     for i in range(number_of_models):
         if number_of_channels == 1:
-            weights_file_name = get_pretrained_network("sysuMediaWmhFlairOnlyModel" + str(i),
-                antsxnet_cache_directory=antsxnet_cache_directory)
+            weights_file_name = get_pretrained_network("sysuMediaWmhFlairOnlyModel" + str(i))
         else:
-            weights_file_name = get_pretrained_network("sysuMediaWmhFlairT1Model" + str(i),
-                antsxnet_cache_directory=antsxnet_cache_directory)
+            weights_file_name = get_pretrained_network("sysuMediaWmhFlairT1Model" + str(i))
         unet_model = create_sysu_media_unet_model_2d((*image_size, number_of_channels))
         unet_loss = binary_dice_coefficient(smoothing_factor=1.)
         unet_model.compile(optimizer=keras.optimizers.Adam(learning_rate=2e-4),
@@ -259,7 +249,6 @@ def hypermapp3r_segmentation(t1,
                              flair,
                              number_of_monte_carlo_iterations=30,
                              do_preprocessing=True,
-                             antsxnet_cache_directory=None,
                              verbose=False):
 
     """
@@ -292,11 +281,6 @@ def hypermapp3r_segmentation(t1,
 
     do_preprocessing : boolean
         See description above.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -335,7 +319,6 @@ def hypermapp3r_segmentation(t1,
             brain_extraction_modality="t1",
             do_bias_correction=True,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         brain_mask = t1_preprocessing['brain_mask']
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * brain_mask
@@ -355,7 +338,6 @@ def hypermapp3r_segmentation(t1,
             brain_extraction_modality=None,
             do_bias_correction=True,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         flair_preprocessed = flair_preprocessing["preprocessed_image"] * brain_mask
 
@@ -392,7 +374,7 @@ def hypermapp3r_segmentation(t1,
         print("    HyperMapp3r: generate network and load weights.")
 
     model = create_hypermapp3r_unet_model_3d((*input_image_size, 2))
-    weights_file_name = get_pretrained_network("hyperMapp3r", antsxnet_cache_directory=antsxnet_cache_directory)
+    weights_file_name = get_pretrained_network("hyperMapp3r")
     model.load_weights(weights_file_name)
 
     if verbose:
@@ -421,7 +403,6 @@ def wmh_segmentation(flair,
                      prediction_batch_size=16,
                      patch_stride_length=32,
                      do_preprocessing=True,
-                     antsxnet_cache_directory=None,
                      verbose=False):
 
     """
@@ -457,15 +438,10 @@ def wmh_segmentation(flair,
         Control memory usage for prediction.  More consequential for GPU-usage.
 
     patch_stride_length : 3-D tuple or int
-        Dictates the stride length for accumulating predicting patches.    
+        Dictates the stride length for accumulating predicting patches.
 
     do_preprocessing : boolean
         perform n4 bias correction, intensity truncation, brain extraction.
-
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -515,7 +491,6 @@ def wmh_segmentation(flair,
             brain_extraction_modality="t1",
             do_bias_correction=True,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         brain_mask = ants.threshold_image(t1_preprocessing["brain_mask"], 0.5, 1, 1, 0)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * brain_mask
@@ -525,7 +500,6 @@ def wmh_segmentation(flair,
             brain_extraction_modality=None,
             do_bias_correction=True,
             do_denoising=False,
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         flair_preprocessed = flair_preprocessing["preprocessed_image"] * brain_mask
 
@@ -561,9 +535,9 @@ def wmh_segmentation(flair,
                                              number_of_filters=number_of_filters)
     weights_file_name = None
     if use_combined_model:
-        weights_file_name = get_pretrained_network("antsxnetWmhOr", antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("antsxnetWmhOr")
     else:
-        weights_file_name = get_pretrained_network("antsxnetWmh", antsxnet_cache_directory=antsxnet_cache_directory)
+        weights_file_name = get_pretrained_network("antsxnetWmh")
     model.load_weights(weights_file_name)
 
     ################################
@@ -607,7 +581,7 @@ def wmh_segmentation(flair,
         print("Total number of patches: ", str(total_number_of_patches))
         print("Prediction batch size: ", str(prediction_batch_size))
         print("Number of batches: ", str(number_of_batches + 1))
-     
+
     prediction = np.zeros((total_number_of_patches, *patch_size, 1))
     for b in range(number_of_batches):
         batchX = None
@@ -619,9 +593,9 @@ def wmh_segmentation(flair,
         indices = range(b * prediction_batch_size, b * prediction_batch_size + batchX.shape[0])
         batchX[:,:,:,:,0] = flair_patches[indices,:,:,:]
         batchX[:,:,:,:,1] = t1_patches[indices,:,:,:]
-        
+
         if verbose:
-            print("Predicting batch ", str(b + 1), " of ", str(number_of_batches))  
+            print("Predicting batch ", str(b + 1), " of ", str(number_of_batches))
         prediction[indices,:,:,:,:] = model.predict(batchX, verbose=verbose)
 
     if verbose:
@@ -639,12 +613,11 @@ def shiva_pvs_segmentation(t1,
                            flair=None,
                            which_model="all",
                            do_preprocessing=True,
-                           antsxnet_cache_directory=None,
                            verbose=False):
 
     """
     Perform segmentation of perivascular (PVS) or Vircho-Robin spaces (VRS).
-    
+
     https://pubmed.ncbi.nlm.nih.gov/34262443/
 
     with the original implementation available here:
@@ -661,7 +634,7 @@ def shiva_pvs_segmentation(t1,
 
     which_model : integer or string
         Several models were trained for the case of T1-only or T1/FLAIR image
-        pairs.  One can use a specific single trained model or the average of 
+        pairs.  One can use a specific single trained model or the average of
         the entire ensemble.  I.e., options are:
             * For T1-only:  0, 1, 2, 3, 4, 5.
             * For T1/FLAIR: 0, 1, 2, 3, 4.
@@ -669,11 +642,6 @@ def shiva_pvs_segmentation(t1,
 
     do_preprocessing : boolean
         perform n4 bias correction, intensity truncation, brain extraction.
-            
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -712,7 +680,6 @@ def shiva_pvs_segmentation(t1,
             do_bias_correction=True,
             do_denoising=False,
             intensity_normalization_type="01",
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         brain_mask = ants.threshold_image(t1_preprocessing["brain_mask"], 0.5, 1, 1, 0)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * brain_mask
@@ -724,7 +691,6 @@ def shiva_pvs_segmentation(t1,
                 do_bias_correction=True,
                 do_denoising=False,
                 intensity_normalization_type="01",
-                antsxnet_cache_directory=antsxnet_cache_directory,
                 verbose=verbose)
             flair_preprocessed = flair_preprocessing["preprocessed_image"] * brain_mask
 
@@ -737,13 +703,13 @@ def shiva_pvs_segmentation(t1,
     image_shape = (160, 214, 176)
     reorient_template = ants.from_numpy(np.ones(image_shape), origin=(0, 0, 0),
                                         spacing=(1, 1, 1), direction=np.eye(3))
-        
+
     center_of_mass_template = ants.get_center_of_mass(reorient_template)
     center_of_mass_image = ants.get_center_of_mass(brain_mask)
     translation = np.round(np.asarray(center_of_mass_image) - np.asarray(center_of_mass_template))
     xfrm = ants.create_ants_transform(transform_type="Euler3DTransform",
         center=np.round(np.asarray(center_of_mass_template)), translation=translation)
-    
+
     t1_preprocessed = ants.apply_ants_transform_to_image(xfrm, t1_preprocessed, reorient_template)
     if flair is not None:
         flair_preprocessed = ants.apply_ants_transform_to_image(xfrm, flair_preprocessed, reorient_template)
@@ -764,8 +730,7 @@ def shiva_pvs_segmentation(t1,
             model_ids = [0, 1, 2, 3, 4, 5]
 
         for i in range(len(model_ids)):
-            model_weights_file = get_pretrained_network("pvs_shiva_t1_" + str(model_ids[i]), 
-                                                        antsxnet_cache_directory=antsxnet_cache_directory)
+            model_weights_file = get_pretrained_network("pvs_shiva_t1_" + str(model_ids[i]))
             if verbose:
                 print("Loading", model_weights_file)
             model = create_shiva_unet_model_3d(number_of_modalities=1)
@@ -775,9 +740,9 @@ def shiva_pvs_segmentation(t1,
             else:
                 batchY += model.predict(batchX, verbose=verbose)
 
-        batchY /= len(model_ids) 
-        
-    else:    
+        batchY /= len(model_ids)
+
+    else:
         batchX = np.zeros((1, *image_shape, 2))
         batchX[0,:,:,:,0] = t1_preprocessed.numpy()
         batchX[0,:,:,:,1] = flair_preprocessed.numpy()
@@ -787,8 +752,7 @@ def shiva_pvs_segmentation(t1,
             model_ids = [0, 1, 2, 3, 4]
 
         for i in range(len(model_ids)):
-            model_weights_file = get_pretrained_network("pvs_shiva_t1_flair_" + str(model_ids[i]),
-                                                        antsxnet_cache_directory=antsxnet_cache_directory)
+            model_weights_file = get_pretrained_network("pvs_shiva_t1_flair_" + str(model_ids[i]))
             if verbose:
                 print("Loading", model_weights_file)
             model = create_shiva_unet_model_3d(number_of_modalities=2)
@@ -798,26 +762,25 @@ def shiva_pvs_segmentation(t1,
             else:
                 batchY += model.predict(batchX, verbose=verbose)
 
-        batchY /= len(model_ids)            
-            
+        batchY /= len(model_ids)
+
     pvs = ants.from_numpy(np.squeeze(batchY), origin=reorient_template.origin,
                           spacing=reorient_template.spacing,
                           direction=reorient_template.direction)
     pvs = ants.apply_ants_transform_to_image(xfrm.invert(), pvs, t1)
     return pvs
-        
+
 def shiva_wmh_segmentation(flair,
                            t1=None,
                            which_model="all",
                            do_preprocessing=True,
-                           antsxnet_cache_directory=None,
                            verbose=False):
 
     """
     Perform segmentation of white matter hyperintensities.
-    
+
     https://pubmed.ncbi.nlm.nih.gov/38050769/
-    
+
     with the original implementation available here:
 
     https://github.com/pboutinaud/SHIVA_WMH
@@ -832,7 +795,7 @@ def shiva_wmh_segmentation(flair,
 
     which_model : integer or string
         Several models were trained for the case of T1-only or T1/FLAIR image
-        pairs.  One can use a specific single trained model or the average of 
+        pairs.  One can use a specific single trained model or the average of
         the entire ensemble.  I.e., options are:
             * For T1-only:  0, 1, 2, 3, 4.
             * For T1/FLAIR: 0, 1, 2, 3, 4.
@@ -840,11 +803,6 @@ def shiva_wmh_segmentation(flair,
 
     do_preprocessing : boolean
         perform n4 bias correction, intensity truncation, brain extraction.
-            
-    antsxnet_cache_directory : string
-        Destination directory for storing the downloaded template and model weights.
-        Since these can be reused, if is None, these data will be downloaded to a
-        ~/.keras/ANTsXNet/.
 
     verbose : boolean
         Print progress to the screen.
@@ -883,7 +841,6 @@ def shiva_wmh_segmentation(flair,
             do_bias_correction=True,
             do_denoising=False,
             intensity_normalization_type="01",
-            antsxnet_cache_directory=antsxnet_cache_directory,
             verbose=verbose)
         brain_mask = ants.threshold_image(flair_preprocessing["brain_mask"], 0.5, 1, 1, 0)
         flair_preprocessed = flair_preprocessing["preprocessed_image"] * brain_mask
@@ -895,7 +852,6 @@ def shiva_wmh_segmentation(flair,
                 do_bias_correction=True,
                 do_denoising=False,
                 intensity_normalization_type="01",
-                antsxnet_cache_directory=antsxnet_cache_directory,
                 verbose=verbose)
             t1_preprocessed = t1_preprocessing["preprocessed_image"] * brain_mask
 
@@ -908,13 +864,13 @@ def shiva_wmh_segmentation(flair,
     image_shape = (160, 214, 176)
     reorient_template = ants.from_numpy(np.ones(image_shape), origin=(0, 0, 0),
                                         spacing=(1, 1, 1), direction=np.eye(3))
-        
+
     center_of_mass_template = ants.get_center_of_mass(reorient_template)
     center_of_mass_image = ants.get_center_of_mass(brain_mask)
     translation = np.round(np.asarray(center_of_mass_image) - np.asarray(center_of_mass_template))
     xfrm = ants.create_ants_transform(transform_type="Euler3DTransform",
         center=np.round(np.asarray(center_of_mass_template)), translation=translation)
-    
+
     flair_preprocessed = ants.apply_ants_transform_to_image(xfrm, flair_preprocessed, reorient_template)
     if t1 is not None:
         t1_preprocessed = ants.apply_ants_transform_to_image(xfrm, t1_preprocessed, reorient_template)
@@ -935,8 +891,7 @@ def shiva_wmh_segmentation(flair,
             model_ids = [0, 1, 2, 3, 4]
 
         for i in range(len(model_ids)):
-            model_weights_file = get_pretrained_network("wmh_shiva_flair_" + str(model_ids[i]), 
-                                                        antsxnet_cache_directory=antsxnet_cache_directory)
+            model_weights_file = get_pretrained_network("wmh_shiva_flair_" + str(model_ids[i]))
             if verbose:
                 print("Loading", model_weights_file)
             model = create_shiva_unet_model_3d(number_of_modalities=1)
@@ -946,9 +901,9 @@ def shiva_wmh_segmentation(flair,
             else:
                 batchY += model.predict(batchX, verbose=verbose)
 
-        batchY /= len(model_ids) 
-        
-    else:    
+        batchY /= len(model_ids)
+
+    else:
         batchX = np.zeros((1, *image_shape, 2))
         batchX[0,:,:,:,0] = t1_preprocessed.numpy()
         batchX[0,:,:,:,1] = flair_preprocessed.numpy()
@@ -958,8 +913,7 @@ def shiva_wmh_segmentation(flair,
             model_ids = [0, 1, 2, 3, 4]
 
         for i in range(len(model_ids)):
-            model_weights_file = get_pretrained_network("wmh_shiva_t1_flair_" + str(model_ids[i]),
-                                                        antsxnet_cache_directory=antsxnet_cache_directory)
+            model_weights_file = get_pretrained_network("wmh_shiva_t1_flair_" + str(model_ids[i]))
             if verbose:
                 print("Loading", model_weights_file)
             model = create_shiva_unet_model_3d(number_of_modalities=2)
@@ -969,11 +923,10 @@ def shiva_wmh_segmentation(flair,
             else:
                 batchY += model.predict(batchX, verbose=verbose)
 
-        batchY /= len(model_ids)            
-            
+        batchY /= len(model_ids)
+
     wmh = ants.from_numpy(np.squeeze(batchY), origin=reorient_template.origin,
                           spacing=reorient_template.spacing,
                           direction=reorient_template.direction)
     wmh = ants.apply_ants_transform_to_image(xfrm.invert(), wmh, flair)
     return wmh
-        


### PR DESCRIPTION
Set once for the whole session, easier than encoding into every call.

I noticed a couple of places in `mouse.py` where the cache directory was not specified, which would lead to data being downloaded in the wrong location. 

Bit of a breaking change, but I think it will be overall more reliable, and most users probably just use the default anyway.