### PR TITLE
ENH:  INtegrate Siq models.

### DIFF
--- a/antspynet/utilities/get_pretrained_network.py
+++ b/antspynet/utilities/get_pretrained_network.py
@@ -179,7 +179,19 @@ def get_pretrained_network(file_id=None,
             "DeepAtroposHcpT1Weights": "https://figshare.com/ndownloader/files/51906071",
             "DeepAtroposHcpT1T2Weights": "https://figshare.com/ndownloader/files/49132498", # "https://figshare.com/ndownloader/files/49132504"
             "DeepAtroposHcpT1FAWeights": "https://figshare.com/ndownloader/files/49132507",
-            "DeepAtroposHcpT1T2FAWeights": "https://figshare.com/ndownloader/files/49132501"
+            "DeepAtroposHcpT1T2FAWeights": "https://figshare.com/ndownloader/files/49132501",
+            "sig_smallshort_train_1x1x2_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339837",
+            "sig_smallshort_train_1x1x2_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339840",
+            "sig_smallshort_train_1x1x3_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339843",
+            "sig_smallshort_train_1x1x3_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339846",
+            "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339849",
+            "sig_smallshort_train_1x1x4_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339852",
+            # "sig_smallshort_train_1x1x6_1chan_featgraderL6_best_", Not available
+            "sig_smallshort_train_1x1x6_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339855",
+            "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339858",
+            "sig_smallshort_train_2x2x2_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339861",
+            "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339867",
+            "sig_smallshort_train_2x2x4_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339864"            
         }
         return(switcher.get(argument, "Invalid argument."))
 
@@ -335,10 +347,21 @@ def get_pretrained_network(file_id=None,
                   "DeepAtroposHcpT1T2Weights",
                   "DeepAtroposHcpT1FAWeights",
                   "DeepAtroposHcpT1T2FAWeights",
+                  "sig_smallshort_train_1x1x2_1chan_featgraderL6_best_mdl",
+                  "sig_smallshort_train_1x1x2_1chan_featvggL6_best_mdl",
+                  "sig_smallshort_train_1x1x3_1chan_featgraderL6_best_mdl",
+                  "sig_smallshort_train_1x1x3_1chan_featvggL6_best_mdl",
+                  "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_",
+                  "sig_smallshort_train_1x1x4_1chan_featvggL6_best_",
+                  "sig_smallshort_train_1x1x6_1chan_featvggL6_best_",
+                  "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_",
+                  "sig_smallshort_train_2x2x2_1chan_featvggL6_best_",
+                  "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_",
+                  "sig_smallshort_train_2x2x4_1chan_featvggL6_best_",
                   "show")
 
     if not file_id in valid_list:
-        raise ValueError("No data with the id you passed - try \"show\" to get list of valid ids.")
+        raise ValueError("No data with the id you passed (" + file_id + ")- try \"show\" to get list of valid ids.")
 
     if file_id == "show":
        return(valid_list)

--- a/antspynet/utilities/get_pretrained_network.py
+++ b/antspynet/utilities/get_pretrained_network.py
@@ -184,14 +184,14 @@ def get_pretrained_network(file_id=None,
             "sig_smallshort_train_1x1x2_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339840",
             "sig_smallshort_train_1x1x3_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339843",
             "sig_smallshort_train_1x1x3_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339846",
-            "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339849",
-            "sig_smallshort_train_1x1x4_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339852",
-            # "sig_smallshort_train_1x1x6_1chan_featgraderL6_best_", Not available
-            "sig_smallshort_train_1x1x6_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339855",
-            "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339858",
-            "sig_smallshort_train_2x2x2_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339861",
-            "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_": "https://figshare.com/ndownloader/files/49339867",
-            "sig_smallshort_train_2x2x4_1chan_featvggL6_best_": "https://figshare.com/ndownloader/files/49339864"            
+            "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339849",
+            "sig_smallshort_train_1x1x4_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339852",
+            # "sig_smallshort_train_1x1x6_1chan_featgraderL6_best_mdl", Not available
+            "sig_smallshort_train_1x1x6_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339855",
+            "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339858",
+            "sig_smallshort_train_2x2x2_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339861",
+            "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_mdl": "https://figshare.com/ndownloader/files/49339867",
+            "sig_smallshort_train_2x2x4_1chan_featvggL6_best_mdl": "https://figshare.com/ndownloader/files/49339864"            
         }
         return(switcher.get(argument, "Invalid argument."))
 
@@ -351,13 +351,13 @@ def get_pretrained_network(file_id=None,
                   "sig_smallshort_train_1x1x2_1chan_featvggL6_best_mdl",
                   "sig_smallshort_train_1x1x3_1chan_featgraderL6_best_mdl",
                   "sig_smallshort_train_1x1x3_1chan_featvggL6_best_mdl",
-                  "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_",
-                  "sig_smallshort_train_1x1x4_1chan_featvggL6_best_",
-                  "sig_smallshort_train_1x1x6_1chan_featvggL6_best_",
-                  "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_",
-                  "sig_smallshort_train_2x2x2_1chan_featvggL6_best_",
-                  "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_",
-                  "sig_smallshort_train_2x2x4_1chan_featvggL6_best_",
+                  "sig_smallshort_train_1x1x4_1chan_featgraderL6_best_mdl",
+                  "sig_smallshort_train_1x1x4_1chan_featvggL6_best_mdl",
+                  "sig_smallshort_train_1x1x6_1chan_featvggL6_best_mdl",
+                  "sig_smallshort_train_2x2x2_1chan_featgraderL6_best_mdl",
+                  "sig_smallshort_train_2x2x2_1chan_featvggL6_best_mdl",
+                  "sig_smallshort_train_2x2x4_1chan_featgraderL6_best_mdl",
+                  "sig_smallshort_train_2x2x4_1chan_featvggL6_best_mdl",
                   "show")
 
     if not file_id in valid_list:

--- a/antspynet/utilities/mri_super_resolution.py
+++ b/antspynet/utilities/mri_super_resolution.py
@@ -2,18 +2,48 @@ import numpy as np
 import tensorflow as tf
 import ants
 
-from warnings import warn
-
-def mri_super_resolution(image, verbose=False):
+def mri_super_resolution(image, 
+                         expansion_factor=[1,1,2],
+                         feature="vgg",
+                         target_range=[1,0], 
+                         poly_order='hist', 
+                         verbose=False):
 
     """
-    Perform super-resolution (2x) of MRI data using deep back projection network.
-
+    Perform super-resolution of MRI data using deep back projection 
+    network.  Work described in
+    
+    https://www.medrxiv.org/content/10.1101/2023.02.02.23285376v1
+    
+    with the GitHub repo located at https://github.com/stnava/siq
+    
+    Note that some preprocessing possibilities for the input includes:
+      * Truncate intensity (see ants.iMath(..., 'TruncateIntensity', ...)
+    
     Arguments
     ---------
     image : ANTsImage
         magnetic resonance image
+        
+    expansion_factor : 3-tuple
+        Specifies the increase in resolution per dimension.  Possibilities
+        include:
+          * [1,1,2]    
+          * [1,1,3]    
+          * [1,1,4]    
+          * [1,1,6]    
+          * [2,2,2]
+          * [2,2,4]
+          
+    feature : string
+        Type of network.  Choices include "grader" or "vgg".
+        
+    target_range : 2-tuple
+        Range for apply_super_resolution_model.
 
+    poly_order : int or 'hist'
+        Parameter for regression matching or specification of histogram matching.
+          
     verbose : boolean
         Print progress to the screen.
 
@@ -27,9 +57,6 @@ def mri_super_resolution(image, verbose=False):
     >>> image_sr = mri_super_resolution(image)
     """
 
-    warn('This method is deprecated.  Please see https://github.com/stnava/siq', 
-         DeprecationWarning, stacklevel=2)
-
     from ..utilities import get_pretrained_network
     from ..utilities import apply_super_resolution_model_to_image
     from ..utilities import regression_match_image
@@ -37,14 +64,25 @@ def mri_super_resolution(image, verbose=False):
     if image.dimension != 3:
         raise ValueError("Image dimension must be 3.")
 
-    model_and_weights_file_name = get_pretrained_network("mriSuperResolution")
-    model_sr = tf.keras.models.load_model(model_and_weights_file_name, compile=False)
+    network_basename = ("sig_smallshort_train_" + 
+                        'x'.join(map(str, expansion_factor)) + 
+                        '_1chan_feat' + feature + 'L6_best_mdl')
+    model_and_weights_filename = get_pretrained_network(network_basename)
+    model_sr = tf.keras.models.load_model(model_and_weights_filename, compile=False)
 
     image_sr = apply_super_resolution_model_to_image(
-        image, model_sr, target_range=(-127.5, 127.5)
-    )
-    image_sr = regression_match_image(
-        image_sr, ants.resample_image_to_target(image, image_sr), poly_order=1
-    )
+        image, model_sr, target_range=target_range, regression_order=None, verbose=verbose)
+    if poly_order is not None:
+        if verbose:
+            print("Match intensity with " + str(poly_order))
+        if poly_order == "hist":
+            if verbose:
+                print("Histogram match input/output images.")
+            image_sr = ants.histogram_match_image(image_sr, image)
+        else:
+            if verbose:
+                print("Regression match input/output images.")
+            image_resampled = ants.resample_image_to_target(image, image_sr)
+            image_sr = regression_match_image(image_sr, image_resampled, poly_order=poly_order)
 
     return image_sr

--- a/antspynet/utilities/super_resolution_utilities.py
+++ b/antspynet/utilities/super_resolution_utilities.py
@@ -375,8 +375,8 @@ def apply_super_resolution_model_to_image(
                 return input_array[:, :, :, :, slice]
 
     expansion_factor = np.asarray(prediction.shape) / np.asarray(image_patches.shape)
-    if channel_axis == 0:
-        FIXME
+    # if channel_axis == 0:
+    #     FIXME
 
     expansion_factor = expansion_factor[1 : (len(expansion_factor) - 1)]
 

--- a/antspynet/utilities/super_resolution_utilities.py
+++ b/antspynet/utilities/super_resolution_utilities.py
@@ -258,9 +258,6 @@ def apply_super_resolution_model_to_image(
     >>> image_sr = apply_super_resolution_model_to_image(image, get_pretrained_network("dbpn4x"))
     """
 
-    warn('This method is deprecated.  Please see https://github.com/stnava/siq', 
-         DeprecationWarning, stacklevel=2)
-
     tflite_flag = False
     channel_axis = 0
     if K.image_data_format() == "channels_last":


### PR DESCRIPTION
Hey @stnava - 

After taking a look at the siq repo, I think I'd like to remove the deprecation and add all the possible single channel models.  I modified antspynet.mri_super_resolution to integrate all the capabilities of siq.inference (except for truncation which the user can perform as a preprocessing step).