### PR TITLE
WIP: optional denoising for deep atropos and dkt

### DIFF
--- a/antspynet/utilities/deep_atropos.py
+++ b/antspynet/utilities/deep_atropos.py
@@ -4,6 +4,7 @@ import ants
 def deep_atropos(t1,
                  do_preprocessing=True,
                  use_spatial_priors=1,
+                 do_denoising=True,
                  verbose=False):
 
     """
@@ -40,6 +41,9 @@ def deep_atropos(t1,
     use_spatial_priors : integer
         Use MNI spatial tissue priors (0 or 1).  Currently, only '0' (no priors) and '1'
         (cerebellar prior only) are the only two options.  Default is 1.
+
+    do_denoising : boolean
+        Activate denoising within preprocessing (default True).
 
     verbose : boolean
         Print progress to the screen.
@@ -80,7 +84,7 @@ def deep_atropos(t1,
                 template="croppedMni152",
                 template_transform_type="antsRegistrationSyNQuickRepro[a]",
                 do_bias_correction=True,
-                do_denoising=True,
+                do_denoising=do_denoising,
                 verbose=verbose)
             t1_preprocessed = t1_preprocessing["preprocessed_image"] * t1_preprocessing['brain_mask']
 

--- a/antspynet/utilities/desikan_killiany_tourville_labeling.py
+++ b/antspynet/utilities/desikan_killiany_tourville_labeling.py
@@ -9,6 +9,7 @@ def desikan_killiany_tourville_labeling(t1,
                                         do_preprocessing=True,
                                         return_probability_images=False,
                                         do_lobar_parcellation=False,
+                                        do_denoising=True,
                                         version=0,
                                         verbose=False):
 
@@ -229,6 +230,9 @@ def desikan_killiany_tourville_labeling(t1,
     do_lobar_parcellation : boolean
         Perform lobar parcellation (also divided by hemisphere).
 
+    do_denoising : boolean
+        Perform denoising in preprocessing of brain image.  May impact reproducibility.
+
     verbose : boolean
         Print progress to the screen.
 
@@ -254,6 +258,7 @@ def desikan_killiany_tourville_labeling(t1,
                                                            do_preprocessing=do_preprocessing,
                                                            return_probability_images=return_probability_images,
                                                            do_lobar_parcellation=do_lobar_parcellation,
+                                                           do_denoising=do_denoising,
                                                            verbose=verbose
                                                            )
     elif version == 1:
@@ -270,6 +275,7 @@ def desikan_killiany_tourville_labeling_version0(t1,
                                                  do_preprocessing=True,
                                                  return_probability_images=False,
                                                  do_lobar_parcellation=False,
+                                                 do_denoising=True
                                                  verbose=False):
 
     from ..architectures import create_unet_model_3d
@@ -296,7 +302,7 @@ def desikan_killiany_tourville_labeling_version0(t1,
             template="croppedMni152",
             template_transform_type=template_transform_type,
             do_bias_correction=True,
-            do_denoising=True,
+            do_denoising=do_denoising,
             verbose=verbose)
         t1_preprocessed = t1_preprocessing["preprocessed_image"] * t1_preprocessing['brain_mask']
 

--- a/antspynet/utilities/desikan_killiany_tourville_labeling.py
+++ b/antspynet/utilities/desikan_killiany_tourville_labeling.py
@@ -275,7 +275,7 @@ def desikan_killiany_tourville_labeling_version0(t1,
                                                  do_preprocessing=True,
                                                  return_probability_images=False,
                                                  do_lobar_parcellation=False,
-                                                 do_denoising=True
+                                                 do_denoising=True,
                                                  verbose=False):
 
     from ..architectures import create_unet_model_3d


### PR DESCRIPTION
This is backward compatible but allows user to turn off denoising in order to increase reproducibility of results.  Other (I believe computationally repeatable but likely slower) options for denoising are available from scikit-image.