### PR TITLE
COMP: Boost tensorflow version to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antspynet"
-version = "0.3.0"
+version = "0.3.2"
 description = "A collection of deep learning architectures ported to the python language and tools for basic medical image processing."
 readme = "README.md"
 authors = [
@@ -21,8 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
-    "tensorflow>=2.11,<=2.17",
-#    "keras<3",
+    "tensorflow",
     "antspyx>=0.6.1",
     "scikit-learn",
     "requests",


### PR DESCRIPTION
This prevents unintended downgrade on modern python, allows installation of numpy 2

The main blocker for this was the requirement of keras<3, which is no longer in place

Tests pass on my Linux machine

Fixes #191 